### PR TITLE
scripts for creating dat and csv files

### DIFF
--- a/alphaFoldFairness/batch-copy.sh
+++ b/alphaFoldFairness/batch-copy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Copy output-data-* to scratch
+find $1 -name "output-*" -type d | xargs -I {} -P 1000 cp -r {} $2;

--- a/alphaFoldFairness/organize-data-ss.py
+++ b/alphaFoldFairness/organize-data-ss.py
@@ -6,10 +6,15 @@ import numpy
 name=sys.argv[1]
 
 pdb_name=name+".pdb"
-ss_name=name+".dat"
+ss_name=name+".dssp"
 out_name=name+".out"
 
-file_ss=open(ss_name,"r")
+try:
+    file_ss=open(ss_name,"r")
+except:
+    ss_name=name+".dat"
+    file_ss=open(ss_name,"r")
+
 file_out=open(out_name,"w+")
 
 # skip the first 28 line for the secondary structure file
@@ -23,4 +28,4 @@ with open(pdb_name) as file_pdb:
         ss=file_ss.readline()[16]
         if (ss==' '):
           ss='~'
-        print(line.split()[3],line.split()[10],ss,file=file_out)
+        print(line.split()[3],line.split()[-2],ss,file=file_out)

--- a/alphaFoldFairness/res_out_2_dat_v2.sh
+++ b/alphaFoldFairness/res_out_2_dat_v2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Find *out files and add them to corresponding *dat files.
+find $1 -type f -name "AF*.out" | xargs -I {} -P 1000 python3 analyze-residue.py {};
+
+#find $1 -type f -name "AF*.out" | while read dir; do
+#    python analyze-residue.py $dir
+#    echo $dir
+#done

--- a/alphaFoldFairness/ss_out_2_csv_v2.sh
+++ b/alphaFoldFairness/ss_out_2_csv_v2.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Find *out files and add them to corresponding *csv files.
+find $1 -type f -name "AF*.out" | xargs -I {} -P 1000 python3 analyze-ss.py {};
+
+#find $1 -type f -name "AF*.out" | while read dir; do
+#    python analyze-ss.py $dir
+#    echo $dir
+#done


### PR DESCRIPTION
batch-copy.sh is used to parallelize and speed up copy operations for millions of files.
ss_out_2_csv and res_out_2_dat help extract info from .out files and classify them according to residue or secondary structure type.